### PR TITLE
Add the results of the process to the success/failure actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ import postServices from '@services/postServices';
 const getPostsTarget = 'posts';
 const addPostsTarget = 'post';
 
+const success = (response) => {
+  console.log('success:', response);
+};
+
+const failure = (error) => {
+  console.log('error', error);
+};
+
 const postActions = {
   getPosts: (success, failure) => ({
     type: GET_POSTS,
@@ -65,5 +73,5 @@ target | String | This is important to get good prop names, for example if `targ
 initialState | * | The initial value ([], {}, '', etc)
 response | Func (optional) | is a callback to handle the response route, for example if you have `data: { data: { title } } ` you could  use `resp => resp.data.data`, so that you can get in your redux state `postData: { title }` instead of `postData: data: { data: { title } }`.
 Error | Func (options) | Same as response option, but to handle errors.
-success | Func | The callback when the response is success
-failure | Func | The callback when you get error
+success | Func (response) | The callback when the response is success.
+failure | Func (error) | The callback when you get error

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-response-middleware",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Single Redux MIddleware with Request/Success/Failure Pattern",
   "main": "./src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -41,14 +41,14 @@ function responseMiddleware() {
               [data]: action.response ? action[response](resp) : resp
             })
           }));
-          if (hasProperty(success)) action[success]();
+          if (hasProperty(success)) action[success](resp);
         }).catch(err => {
           next(_objectSpread(_objectSpread({}, action), {}, {
             payload: _objectSpread(_objectSpread({}, payload), {}, {
               [error]: action.error ? action.error(err) : err
             })
           }));
-          if (hasProperty(failure)) action[failure]();
+          if (hasProperty(failure)) action[failure](err);
         });
       } else {
         throw new Error("action.service should be a promise");


### PR DESCRIPTION
With this change we can access to the result in the success or error action:

Example
```js
const success = (response) => {
   console.log(response);
}

const failure = (err) => {
   console.error(err);
}

 getPosts: (success, failure) => ({
    type: GET_POSTS,
    target: getPostsTarget,
    service: postServices.getPosts,
    response: resp => resp.data,
    error: error => error.data,
    success,
    failure,
  }),
```